### PR TITLE
issue #7: cannot find module 'react-native-sodium'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # See https://help.github.com/ignore-files/ for more about ignoring files.
+.idea
 
 # dependencies
 /node_modules

--- a/react-native-etebase/src/Etebase.ts
+++ b/react-native-etebase/src/Etebase.ts
@@ -1,8 +1,25 @@
+// Shim document if it doesn't exist (e.g. on React native)
+if ((typeof global !== "undefined") && !(global as any).document) {
+    (global as any).document = {};
+}
+
 import "react-native-get-random-values";
 import RnSodium from "react-native-sodium";
+import sodium from 'libsodium-wrappers';
 
-import { _setRnSodium } from "etebase";
+import { _setDeriveKeyImplementation } from "etebase"
 
-_setRnSodium(RnSodium);
+_setDeriveKeyImplementation(async function (salt: Uint8Array, password: string) {
+    const ret = await RnSodium.crypto_pwhash(
+        32,
+        sodium.to_base64(sodium.from_string(password), sodium.base64_variants.ORIGINAL),
+        sodium.to_base64(salt, sodium.base64_variants.ORIGINAL),
+        sodium.crypto_pwhash_OPSLIMIT_SENSITIVE,
+        sodium.crypto_pwhash_MEMLIMIT_MODERATE,
+        sodium.crypto_pwhash_ALG_DEFAULT,
+    )
+
+    return sodium.from_base64(ret, sodium.base64_variants.ORIGINAL)
+})
 
 export * from "etebase";

--- a/src/Etebase.ts
+++ b/src/Etebase.ts
@@ -1,9 +1,14 @@
+// Shim document if it doesn't exist (e.g. on React native)
+if ((typeof global !== "undefined") && !(global as any).document) {
+  (global as any).document = {};
+}
+
 import URI from "urijs";
 
 import * as Constants from "./Constants";
 
 import { deriveKey, concatArrayBuffers, BoxCryptoManager, ready } from "./Crypto";
-export { ready, getPrettyFingerprint, _setRnSodium } from "./Crypto";
+export { ready, getPrettyFingerprint, _setDeriveKeyImplementation } from "./Crypto";
 import { ConflictError, UnauthorizedError } from "./Exceptions";
 export * from "./Exceptions";
 import { base64, fromBase64, toBase64, fromString, toString, randomBytes, symmetricKeyLength, msgpackEncode, msgpackDecode, bufferUnpad } from "./Helpers";


### PR DESCRIPTION
- the 'core' library included 'react-native-sodium' type references
  on it's public api, due to the function used to inject it when
  running in react native. This means that typescript compilation
  would fail on web / nodejs unless you installed the react-native-sodium
  dependency in your project, or disabled type checking of libraries

- instead of injecting the whole object, just inject a callback that
  can do that operation that differs between web and react native,
  this means that the core library no longer knows that react native
  exists

- one drawback would be if more operations start diverging, however
  if this happened I would reccomend defining an interface abstracting
  sodium and creating a web / react native implementation of this to
  inject

**Note: having a bit of trouble getting the tests to run successfully - need to get my local server setup correctly for it I think as it fails on master as well**