### PR TITLE
Types: type custom item meta data

### DIFF
--- a/src/EncryptedModels.ts
+++ b/src/EncryptedModels.ts
@@ -9,14 +9,14 @@ export type CollectionType = string;
 
 export type ContentType = File | Blob | Uint8Array | string | null;
 
-export interface ItemMetadata {
+export type ItemMetadata<T = {}> = {
   type?: string;
   name?: string; // The name of the item, e.g. filename in case of files
   mtime?: number; // The modification time
 
   description?: string;
   color?: string;
-}
+} & T;
 
 export type ChunkJson = [base64, Uint8Array?];
 
@@ -400,7 +400,7 @@ export class EncryptedCollection {
   public accessLevel: CollectionAccessLevel;
   public stoken: string | null; // FIXME: hack, we shouldn't expose it here...
 
-  public static async create(parentCryptoManager: AccountCryptoManager, collectionTypeName: string, meta: ItemMetadata, content: Uint8Array): Promise<EncryptedCollection> {
+  public static async create<T>(parentCryptoManager: AccountCryptoManager, collectionTypeName: string, meta: ItemMetadata<T>, content: Uint8Array): Promise<EncryptedCollection> {
     const ret = new EncryptedCollection();
     ret.collectionType = parentCryptoManager.colTypeToUid(collectionTypeName);
     ret.collectionKey = parentCryptoManager.encrypt(randomBytes(symmetricKeyLength), ret.collectionType);
@@ -474,12 +474,12 @@ export class EncryptedCollection {
     return this.item.verify(itemCryptoManager);
   }
 
-  public setMeta(cryptoManager: CollectionCryptoManager, meta: ItemMetadata): void {
+  public setMeta<T>(cryptoManager: CollectionCryptoManager, meta: ItemMetadata<T>): void {
     const itemCryptoManager = this.item.getCryptoManager(cryptoManager);
     this.item.setMeta(itemCryptoManager, meta);
   }
 
-  public getMeta(cryptoManager: CollectionCryptoManager): ItemMetadata {
+  public getMeta<T>(cryptoManager: CollectionCryptoManager): ItemMetadata<T> {
     this.verify(cryptoManager);
     const itemCryptoManager = this.item.getCryptoManager(cryptoManager);
     return this.item.getMeta(itemCryptoManager);
@@ -571,7 +571,7 @@ export class EncryptedCollectionItem {
 
   public lastEtag: string | null;
 
-  public static async create(parentCryptoManager: CollectionCryptoManager, meta: ItemMetadata, content: Uint8Array): Promise<EncryptedCollectionItem> {
+  public static async create<T>(parentCryptoManager: CollectionCryptoManager, meta: ItemMetadata<T>, content: Uint8Array): Promise<EncryptedCollectionItem> {
     const ret = new EncryptedCollectionItem();
     ret.uid = genUidBase64();
     ret.version = Constants.CURRENT_VERSION;
@@ -659,7 +659,7 @@ export class EncryptedCollectionItem {
     return this.content.verify(cryptoManager, this.getAdditionalMacData());
   }
 
-  public setMeta(cryptoManager: CollectionItemCryptoManager, meta: ItemMetadata): void {
+  public setMeta<T>(cryptoManager: CollectionItemCryptoManager, meta: ItemMetadata<T>): void {
     let rev = this.content;
     if (!this.isLocallyChanged()) {
       rev = this.content.clone();
@@ -669,7 +669,7 @@ export class EncryptedCollectionItem {
     this.content = rev;
   }
 
-  public getMeta(cryptoManager: CollectionItemCryptoManager): ItemMetadata {
+  public getMeta<T>(cryptoManager: CollectionItemCryptoManager): ItemMetadata<T> {
     this.verify(cryptoManager);
     return this.content.getMeta(cryptoManager, this.getAdditionalMacData());
   }

--- a/src/Etebase.test.ts
+++ b/src/Etebase.test.ts
@@ -13,7 +13,7 @@ let etebase: Etebase.Account;
 
 const colType = "some.coltype";
 
-async function verifyCollection(col: Etebase.Collection, meta: Etebase.ItemMetadata, content: Uint8Array) {
+async function verifyCollection<T>(col: Etebase.Collection, meta: Etebase.ItemMetadata<T>, content: Uint8Array) {
   col.verify();
   const decryptedMeta = col.getMeta();
   expect(decryptedMeta).toEqual(meta);
@@ -21,7 +21,7 @@ async function verifyCollection(col: Etebase.Collection, meta: Etebase.ItemMetad
   expect(toBase64(decryptedContent)).toEqual(toBase64(content));
 }
 
-async function verifyItem(item: Etebase.Item, meta: Etebase.ItemMetadata, content: Uint8Array) {
+async function verifyItem<T>(item: Etebase.Item, meta: Etebase.ItemMetadata<T>, content: Uint8Array) {
   item.verify();
   const decryptedMeta = item.getMeta();
   expect(decryptedMeta).toEqual(meta);

--- a/src/Etebase.ts
+++ b/src/Etebase.ts
@@ -288,7 +288,7 @@ export class CollectionManager {
     this.onlineManager = new CollectionManagerOnline(this.etebase);
   }
 
-  public async create(colType: string, meta: ItemMetadata, content: Uint8Array | string): Promise<Collection> {
+  public async create<T>(colType: string, meta: ItemMetadata<T>, content: Uint8Array | string): Promise<Collection> {
     const uintcontent = (content instanceof Uint8Array) ? content : fromString(content);
     const mainCryptoManager = this.etebase._getCryptoManager();
     const encryptedCollection = await EncryptedCollection.create(mainCryptoManager, colType, meta, uintcontent);
@@ -366,7 +366,7 @@ export class ItemManager {
     this.collectionUid = col.uid;
   }
 
-  public async create(meta: ItemMetadata, content: Uint8Array | string): Promise<Item> {
+  public async create<T>(meta: ItemMetadata<T>, content: Uint8Array | string): Promise<Item> {
     const uintcontent = (content instanceof Uint8Array) ? content : fromString(content);
     const encryptedItem = await EncryptedCollectionItem.create(this.collectionCryptoManager, meta, uintcontent);
     return new Item(this.collectionUid, encryptedItem.getCryptoManager(this.collectionCryptoManager), encryptedItem);
@@ -576,11 +576,11 @@ export class Collection {
     return this.encryptedCollection.verify(this.cryptoManager);
   }
 
-  public setMeta(meta: ItemMetadata): void {
+  public setMeta<T>(meta: ItemMetadata<T>): void {
     this.encryptedCollection.setMeta(this.cryptoManager, meta);
   }
 
-  public getMeta(): ItemMetadata {
+  public getMeta<T>(): ItemMetadata<T> {
     return this.encryptedCollection.getMeta(this.cryptoManager);
   }
 
@@ -652,11 +652,11 @@ export class Item {
     return this.encryptedItem.verify(this.cryptoManager);
   }
 
-  public setMeta(meta: ItemMetadata): void {
+  public setMeta<T>(meta: ItemMetadata<T>): void {
     this.encryptedItem.setMeta(this.cryptoManager, meta);
   }
 
-  public getMeta(): ItemMetadata {
+  public getMeta<T>(): ItemMetadata<T> {
     return this.encryptedItem.getMeta(this.cryptoManager);
   }
 


### PR DESCRIPTION
This adds the possibility to define custom types in typescript to extend ItemMetadata. Even though this was already possible to add custom data to ItemMetadata it would throw a typescript error.

With this PR it's possible to define the custom meta data and use it without errors:
```ts
const owner = col.getMeta<{ owner: string }>().owner;

// this threw an error as owner was not part of ItemMetadata
// now it's inferred as ItemMetadata<{ owner: string }>
colMgr.create("", { owner: "me" }, "");
```