### PR TITLE
Converting Uint8Array.from() to new Uint8Array()

### DIFF
--- a/src/EncryptedModels.ts
+++ b/src/EncryptedModels.ts
@@ -242,7 +242,7 @@ class EncryptedRevision<CM extends CollectionItemCryptoManager> {
 
   private calculateAdHash(cryptoManager: CM, additionalData: Uint8Array) {
     const cryptoMac = cryptoManager.getCryptoMac();
-    cryptoMac.update(Uint8Array.from([(this.deleted) ? 1 : 0]));
+    cryptoMac.update(new Uint8Array([(this.deleted) ? 1 : 0]));
     cryptoMac.updateWithLenPrefix(additionalData);
 
     // We hash the chunks separately so that the server can (in the future) return just the hash instead of the full

--- a/src/Etebase.ts
+++ b/src/Etebase.ts
@@ -228,7 +228,7 @@ export class Account {
 
     const ret: AccountDataStored = {
       version,
-      encryptedData: cryptoManager.encrypt(msgpackEncode(content), Uint8Array.from([version])),
+      encryptedData: cryptoManager.encrypt(msgpackEncode(content), new Uint8Array([version])),
     };
 
     return toBase64(msgpackEncode(ret));
@@ -243,7 +243,7 @@ export class Account {
     const cryptoManager = new StorageCryptoManager(encryptionKey, accountDataStored.version);
 
     const accountData = msgpackDecode(
-      cryptoManager.decrypt(accountDataStored.encryptedData, Uint8Array.from([accountDataStored.version]))
+      cryptoManager.decrypt(accountDataStored.encryptedData, new Uint8Array([accountDataStored.version]))
     ) as AccountData;
 
     const ret = new this(cryptoManager.decrypt(accountData.key), accountData.version);

--- a/src/Helpers.ts
+++ b/src/Helpers.ts
@@ -126,7 +126,7 @@ export function msgpackDecode(buffer: ArrayLike<number> | ArrayBuffer): unknown 
 
 export function numToUint8Array(num: number): Uint8Array {
   // We are using little-endian because on most platforms it'll mean zero-conversion
-  return Uint8Array.from([
+  return new Uint8Array([
     num & 255,
     (num >> 8) & 255,
     (num >> 16) & 255,


### PR DESCRIPTION
When using Etebase in a Typescript/React Native environment, I ran into this error on login/signup ... and maybe a few other operations.

`TypeError: TypedArray.from requires its this argument subclass a TypedArray constructor`

And found a similar issues reported here:

https://github.com/openpgpjs/openpgpjs/issues/1076
https://github.com/zloirock/core-js/issues/285

I'm not familiar with Uint8Array, so I don't know if there's a meaningful difference between the two constructor methods. If smarter people than me say that there's no difference, maybe it's worth changing these constructors to avoid issues?

FWIW, I've been using the alternate constructors in my own fork and haven't run into any issues for a week or so ...
