### PR TITLE
fix: Correctly map deduplicated chunk indices when setting content

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etebase",
-  "version": "0.43.0",
+  "version": "0.44.0",
   "description": "Etebase TypeScript API for the web and node",
   "type": "commonjs",
   "main": "dist/lib-cjs/Etebase.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "etebase",
-  "version": "0.44.0",
+  "version": "0.43.0",
   "description": "Etebase TypeScript API for the web and node",
   "type": "commonjs",
   "main": "dist/lib-cjs/Etebase.js",

--- a/src/Etebase.test.ts
+++ b/src/Etebase.test.ts
@@ -5,7 +5,7 @@ import * as Etebase from "./Etebase";
 import { USER, USER2, sessionStorageKey } from "./TestConstants";
 
 import { Authenticator, PrefetchOption } from "./OnlineManagers";
-import { fromBase64, fromString, msgpackEncode, msgpackDecode, randomBytesDeterministic, toBase64, toString } from "./Helpers";
+import { fromBase64, fromString, msgpackEncode, msgpackDecode, randomBytesDeterministic, toBase64 } from "./Helpers";
 
 const testApiBase = process.env.ETEBASE_TEST_API_URL ?? "http://localhost:8033";
 

--- a/src/Etebase.test.ts
+++ b/src/Etebase.test.ts
@@ -1705,32 +1705,22 @@ describe("Chunking files", () => {
   it("Duplicate Chunks", async () => {
     const collectionManager = etebase.getCollectionManager();
     const col = await collectionManager.create(colType, {}, "");
-
     const buf = randomBytesDeterministic(10 * 1024, new Uint8Array(32)); // 10kb of psuedorandom data
-    const content = JSON.stringify([buf, buf, buf, buf]);
-
+    const content = new Uint8Array([...buf, ...buf, ...buf, ...buf]);
     await col.setContent(content);
-
     await collectionManager.transaction(col);
-    const decryptedContent = await col.getContent();
-
-    const out = toString(decryptedContent);
+    const out = await col.getContent();
     expect(out).toEqual(content);
   });
 
   it("Regular Chunks", async () => {
     const collectionManager = etebase.getCollectionManager();
     const col = await collectionManager.create(colType, {}, "");
-
     const buf = randomBytesDeterministic(100 * 1024, new Uint8Array(32));
-    const content = JSON.stringify(buf);
-
+    const content = new Uint8Array(buf);
     await col.setContent(content);
-
     await collectionManager.transaction(col);
-    const decryptedContent = await col.getContent();
-
-    const out = toString(decryptedContent);
+    const out = await col.getContent();
     expect(out).toEqual(content);
   });
 
@@ -1738,14 +1728,10 @@ describe("Chunking files", () => {
     const collectionManager = etebase.getCollectionManager();
     const col = await collectionManager.create(colType, {}, "");
 
-    const content = JSON.stringify("foo");
-
+    const content = new Uint8Array([1]);
     await col.setContent(content);
-
     await collectionManager.transaction(col);
-    const decryptedContent = await col.getContent();
-
-    const out = toString(decryptedContent);
+    const out = await col.getContent();
     expect(out).toEqual(content);
   });
 });


### PR DESCRIPTION
Previously, if a chunk was removed as a duplicate, the indices would be incorrect and getContent wouldn't be able to piece them back together.

This keeps the same logic, but ensures that the indices correctly point to the elements in the new chunks array. Also adds tests to illustrate the issue.

#51 
